### PR TITLE
Update changes to get code running on Python 3 using antlr_python3_runtime-3.1.3.

### DIFF
--- a/bin/j2py
+++ b/bin/j2py
@@ -143,16 +143,16 @@ def runTransform(options):
 
     if options.lexertokens:
         for idx, tok in enumerate(tree.parser.input.tokens):
-            print >> sys.stderr, '{0}  {1}'.format(idx, tok)
-        print >> sys.stderr
+            print(f'{idx}  {tok}', file=sys.stderr)
+        print(file=sys.stderr)
 
     if options.javaast:
         tree.dump(sys.stderr)
-        print >> sys.stderr
+        print(file=sys.stderr)
 
     if options.pytree:
         module.dumpRepr(sys.stderr)
-        print >> sys.stderr
+        print(file=sys.stderr)
 
     if not options.skipsource:
         if fileout == filedefault:
@@ -160,7 +160,7 @@ def runTransform(options):
         else:
             output = open(fileout, 'w')
         module.name = path.splitext(filein)[0] if filein != '-' else '<stdin>'
-        print >> output, source
+        print(source, file=output)
 
     if not options.skipcompile:
         try:

--- a/bin/j2py
+++ b/bin/j2py
@@ -6,10 +6,11 @@ This is all very ordinary.  We import the package bits, open and read
 a file, translate it, and write it out.
 
 """
+import io
 import sys
 from argparse import ArgumentParser, ArgumentTypeError
 from collections import defaultdict
-from logging import _levelNames as logLevels, exception, warning, info, basicConfig
+from logging import _nameToLevel as logLevels, exception, warning, info, basicConfig
 from os import path, makedirs
 from time import time
 
@@ -60,8 +61,8 @@ def runOneOrMany(options):
     """ Runs our main transformer with each of the input files. """
     infile, outfile = options.inputfile, options.outputfile
 
-    if infile and not isinstance(infile, file) and path.isdir(infile):
-        if outfile and not isinstance(outfile, file) and not path.isdir(outfile):
+    if infile and not isinstance(infile, io.IOBase) and path.isdir(infile):
+        if outfile and not isinstance(outfile, io.IOBase) and not path.isdir(outfile):
             warning('Must specify output directory or stdout when using input directory.')
             return 2
         def walker(arg, dirname, files):
@@ -69,7 +70,7 @@ def runOneOrMany(options):
                 fullname = path.join(dirname, name)
                 options.inputfile = fullname
                 info('opening %s', fullname)
-                if outfile and outfile != '-' and not isinstance(outfile, file):
+                if outfile and outfile != '-' and not isinstance(outfile, io.IOBase):
                     full = path.abspath(path.join(outfile, fullname))
                     head, tail = path.split(full)
                     tail = path.splitext(tail)[0] + '.py'
@@ -89,15 +90,15 @@ def runTransform(options):
     timed['overall']
 
     filein = fileout = filedefault = '-'
-    if options.inputfile and not isinstance(options.inputfile, file):
+    if options.inputfile and not isinstance(options.inputfile, io.IOBase):
         filein = options.inputfile
-    if options.outputfile and not isinstance(options.outputfile, file):
+    if options.outputfile and not isinstance(options.outputfile, io.IOBase):
         fileout = options.outputfile
     elif fileout != filedefault:
         fileout = '%s.py' % (path.splitext(filein)[0])
 
     configs = options.configs
-    if options.configdirs and not isinstance(filein, file):
+    if options.configdirs and not isinstance(filein, io.IOBase):
         for configdir in options.configdirs:
             dirname = configFromDir(filein, configdir)
             if path.exists(dirname):
@@ -110,15 +111,15 @@ def runTransform(options):
             source = open(filein).read()
         else:
             source = sys.stdin.read()
-    except (IOError, ), exc:
+    except (IOError, ) as exc:
         code, msg = exc.args[0:2]
-        print 'IOError: %s.' % (msg, )
+        print(f'IOError: {msg}.')
         return code
 
     timed['comp']
     try:
         tree = buildAST(source)
-    except (Exception, ), exc:
+    except (Exception, ) as exc:
         exception('exception while parsing')
         return 1
     timed['comp_finish']
@@ -164,7 +165,7 @@ def runTransform(options):
     if not options.skipcompile:
         try:
             compile(source, '<string>', 'exec')
-        except (SyntaxError, ), ex:
+        except (SyntaxError, ) as ex:
             warning('Generated source has invalid syntax. %s', ex)
         else:
             info('Generated source has valid syntax.')

--- a/java2python/compiler/template.py
+++ b/java2python/compiler/template.py
@@ -157,7 +157,7 @@ class Base(object, metaclass=FactoryTypeDetector):
         for klass in self.parents(lambda v:v.isClass):
             if name in klass.variables:
                 try:
-                    method = self.parents(lambda v:v.isMethod).next()
+                    method = next(self.parents(lambda v:v.isMethod))
                 except (StopIteration, ):
                     return name
                 if name in [p['name'] for p in method.parameters]:

--- a/java2python/compiler/visitor.py
+++ b/java2python/compiler/visitor.py
@@ -540,7 +540,7 @@ class MethodContent(Base):
 
     def acceptSynchronized(self, node, memo):
         """ Accept and process a synchronized statement (not a modifier). """
-        module = self.parents(lambda x:x.isModule).next()
+        module = next(self.parents(lambda x:x.isModule))
         module.needsSyncHelpers = True
         if node.parent.type == tokens.MODIFIER_LIST:
             # Skip any synchronized modifier
@@ -700,7 +700,7 @@ class Expression(Base):
                 name = node.firstChildOfType(tokens.IDENT).text
                 handler = self.configHandler('VariableNaming')
                 rename = handler(name)
-                block = self.parents(lambda x:x.isMethod).next()
+                block = next(self.parents(lambda x:x.isMethod))
                 if pre:
                     left = name
                 else:
@@ -725,7 +725,7 @@ class Expression(Base):
         self.fs = 'bsr(' + FS.l + ', ' + FS.r + ')'
         self.left, self.right = visitors = factory(parent=self), factory()
         self.zipWalk(node.children, visitors, memo)
-        module = self.parents(lambda x:x.isModule).next()
+        module = next(self.parents(lambda x:x.isModule))
         module.needsBsrFunc = True
 
     def acceptBitShiftRightAssign(self, node, memo):
@@ -734,7 +734,7 @@ class Expression(Base):
         self.fs = FS.l + ' = bsr(' + FS.l + ', ' + FS.r + ')'
         self.left, self.right = visitors = factory(parent=self), factory()
         self.zipWalk(node.children, visitors, memo)
-        module = self.parents(lambda x:x.isModule).next()
+        module = next(self.parents(lambda x:x.isModule))
         module.needsBsrFunc = True
 
     def acceptClassConstructorCall(self, node, memo):
@@ -810,12 +810,12 @@ class Expression(Base):
 
     def acceptSuper(self, node, memo):
         """ Accept and process a super expression. """
-        cls = self.parents(lambda c:c.isClass).next()
+        cls = next(self.parents(lambda c:c.isClass))
         self.right = self.factory.expr(fs='super({name}, self)'.format(name=cls.name))
 
     def acceptSuperConstructorCall(self, node, memo):
         """ Accept and process a super constructor call. """
-        cls = self.parents(lambda c:c.isClass).next()
+        cls = next(self.parents(lambda c:c.isClass))
         fs = 'super(' + FS.l + ', self).__init__(' + FS.r + ')'
         self.right = self.factory.expr(fs=fs, left=cls.name)
         return self.right

--- a/java2python/lang/base.py
+++ b/java2python/lang/base.py
@@ -180,13 +180,13 @@ class LocalTree(CommonTree):
                 args[2] = ' ' + self.colorText(ttyp, token.text)
             for com in self.selectComments(start, seen):
                 for line in self.colorComments(com):
-                    print >> fd, '{0}{1}'.format(indent, line)
-            print >> fd, nform.format(*args)
+                    print(f'{indent}{line}', file=fd)
+            print(nform.format(*args), file=fd)
             for child in root.getChildren():
                 innerDump(child, offset+1)
             for com in self.selectComments(root.tokenStopIndex, seen):
                 for line in self.colorComments(com):
-                    print >> fd, '{0}{1}'.format(indent, line)
+                    print(f'{indent}{line}', file=fd)
         innerDump(self, level)
 
     def dumps(self, level=0):

--- a/java2python/mod/basic.py
+++ b/java2python/mod/basic.py
@@ -129,13 +129,13 @@ def maybeAbstractMethod(method):
 
 def maybeSynchronizedMethod(method):
     if 'synchronized' in method.modifiers:
-        module = method.parents(lambda x:x.isModule).next()
+        module = next(method.parents(lambda x:x.isModule))
         module.needsSyncHelpers = True
         yield '@synchronized'
 
 
 def globalNameCounter(original, counter=count()):
-    return '__{0}_{1}'.format(original, counter.next())
+    return '__{0}_{1}'.format(original, next(counter))
 
 
 def getBsrSrc():

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,8 @@ setup(
     author='Troy Melhase',
     author_email='troy@troy.io',
 
-    url='https://github.com/natural/java2python/',
-    download_url='https://github.com/downloads/natural/java2python/java2python-0.5.1.tar.gz',
-
+    url='https://github.com/GEGlobalResearch/java2python/',
+    download_url='https://github.com/GEGlobalResearch/java2python/archive/master.zip',
     keywords=['java', 'java2python', 'compiler'],
     classifiers=filter(None, classifiers.split('\n')),
 
@@ -81,6 +80,7 @@ setup(
         ('doc', doc_files()),
         ],
 
-    install_requires=['antlr_python_runtime==3.1.3'],
-
+    install_requires=[
+        'antlr_python_runtime@https://github.com/altigee/antlr-python3-runtime-3.1.3/archive/master.zip',
+    ],
     )


### PR DESCRIPTION
These changes should bring the code up to a functional state for Python 3.8, including the retrieval of an antlr_python_runtime updated for Python 3.

Downloading the archive and executing `pip install .` from within the file directory of the downloaded target should, using this setup.py, install:

`java2python`
`antlr_python3_runtime-3.1.3` (as `antlr_python_runtime` for dependency and `antlr3` as package)
   [from https://github.com/altigee/antlr-python3-runtime-3.1.3/archive/master.zip]

It's worth noting that Issue https://github.com/natural/java2python/issues/62 on the upstream repo is still present, but seems to have an unincorporated fix, in PR https://github.com/natural/java2python/pull/32 on that repo, that does seem to work.